### PR TITLE
Fix scale function when called with limit == True

### DIFF
--- a/vsscale/funcs.py
+++ b/vsscale/funcs.py
@@ -169,8 +169,8 @@ class ClampScaler(GenericScaler):
             merged = norm_expr(
                 [ref, smooth, smooth.std.Maximum(), smooth.std.Minimum()],
                 expression, merge_weight=merge_weight, ref_weight=1.0 - merge_weight,
-                undershoot=scale_value(self.undershoot, clip),
-                overshoot=scale_value(self.overshoot, clip),
+                undershoot=scale_value(self.undershoot, clip, clip),
+                overshoot=scale_value(self.overshoot, clip, clip),
                 clamp_max=[scale_8bit(clip, 235), scale_8bit(clip, 240)]
             )
         else:


### PR DESCRIPTION
`scale_value` requires both `input_depth` and `output_depth` parameters to be passed. Currently since `output_depth` is not passed, it errors. This breaks some upstream functions such as `based_aa` as well.